### PR TITLE
patch: Page Animation implemented with transitions

### DIFF
--- a/src/components/home/PaginationControls.vue
+++ b/src/components/home/PaginationControls.vue
@@ -28,7 +28,6 @@ import {computed, onMounted, ref, watch} from "vue";
 interface PaginationControlsProps {
   currentPage: number;
   totalPages: number;
-  animationMutex: boolean;
 }
 
 const props = defineProps<PaginationControlsProps>();
@@ -78,7 +77,7 @@ const onPageChangeEvent = () => {
 }
 
 const onPrevious = () => {
-  if (props.currentPage === 1 || props.animationMutex) return;
+  if (props.currentPage === 1) return;
   if (props.currentPage <= props.totalPages && props.currentPage > 4) {
     customPage.value = props.currentPage - 1
   }
@@ -86,7 +85,7 @@ const onPrevious = () => {
 }
 
 const onNext = () => {
-  if (props.currentPage === props.totalPages || props.animationMutex) return;
+  if (props.currentPage === props.totalPages) return;
   if (props.currentPage >= 3 && props.currentPage <= props.totalPages) {
     customPage.value = props.currentPage + 1
   }


### PR DESCRIPTION
# Feedback by @gganon:

## Card swiping animation

At first when i saw your animation code for the card pages in HomeView.vue, I was like "couldn't he have used a Vue <Transition> for this instead of manually setting classes"

Aaaand this sent me down a 2 hour rabbit hole lol. In the end I did get it working with Transitions but there was downside where if you change pages it, for a split second, the contents of the previous and next page will be visible at the same time and I couldn't figure out how to fix that. So I abandoned that track. I think the way you implemented it is the easier way. But if you're curious I've explained that adventure below with a link to a forked branch with the code for you try and (and see the bug i was talking about).

I do have one suggestion with the animation code though. Currently you're applying and removing the animation with "imperative" code. ie, your code is manually setting and removing css classes with dom functions (.classList.add(), .classList.remove()). But with Vue you can also solve this with "declarative" code which is a lot neater

Take a look at the class based animation example here: https://vuejs.org/guide/extras/animation.html#class-based-animations

I think you could do something similar in your code where you set a ref flag(s) and your template uses that object syntax to conditionally set or unset classes on the element. (There are some other syntaxes available for dynamically setting/unsetting CSS classes on Vue elements: https://vuejs.org/guide/essentials/class-and-style.html#binding-html-classes)

## 3b. (Vue Transitions failed sidequest)
Vue transitions are a really cool feature where vue will automatically set and unset classes on your elements for you to trigger animations when something in your enters or exits the screen

Transitions are triggered a few different ways, as seen in this list here: https://vuejs.org/guide/built-ins/transition.html
But most of those triggers have to do with conditional rendering. That's not the case with your card list though. Your cardlist is always visible but the individual card items change as cartoons are loaded. So I used the last trigger in that list: changing key attribute.

The key attribute is an interesting Vue attribute usually used in lists to help vue uniquely identify list items. You can read details about it here: https://vuejs.org/api/built-in-special-attributes.html#key but summary it helps Vue decide when to recycle and patch elements and when to completely remove and re-render them from scratch.

What I did was I set the key to the current page. That way when the page changes, Vue will completely remove the current set of cards and re-render a new set of cards. And by wrapping all of this inside <Transition>, vue will automatically set and unset classes for the animation so that you don't have to manually set and unset those classes yourself.

But I think there's a problem with the way Vue handles a changing key attribute when transitions are involved. It seems to first keep the old key element and the new key element visible for one frame and then in the next frame it removes the old key element. This was causing a bug where when you switch pages you see the contents of both pages for a split second after while the page swipe transition happens. It's very annoying lol. I can't find a way to tell vue to remove the hide the old page and show the new page in the same frame. So I abandoned this approach.